### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ Reverted changes in `1.0.1`.
 
 ## [1.0.1](https://github.com/andreamazz/UIView-draggable/releases/tag/1.0.1)  
 
-###Fixed
+### Fixed
 
 - Issue #12 
 
@@ -40,6 +40,6 @@ Stable release.
 
 ## [0.6](https://github.com/andreamazz/UIView-draggable/releases/tag/0.6)  
 
-###Added  
+### Added  
 - Carthage support
 

--- a/UIViewDraggableDemo/Pods/Expecta/README.md
+++ b/UIViewDraggableDemo/Pods/Expecta/README.md
@@ -1,4 +1,4 @@
-#Expecta
+# Expecta
 
 [![Build Status](http://img.shields.io/travis/specta/expecta/master.svg?style=flat)](https://travis-ci.org/specta/expecta)
 [![Pod Version](http://img.shields.io/cocoapods/v/Expecta.svg?style=flat)](http://cocoadocs.org/docsets/Expecta/)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
